### PR TITLE
Fixed long identifier paths in filters

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -178,6 +178,9 @@ identifier                  =
  * OData query options
  */
 
+// callback
+callback                    =   "$callback=" a:identifier { return { '$callback': a }; }
+
 // $top
 top                         =   "$top=" a:INT { return { '$top': ~~a }; }
                             /   "$top=" .* { return {"error": 'invalid $top parameter'}; }
@@ -231,12 +234,10 @@ select                      =   "$select=" list:selectList { return { "$select":
                             /   "$select=" .* { return {"error": 'invalid $select parameter'}; }
 
 identifierPathParts         =   "/" i:identifierPart list:identifierPathParts? {
-                                    if (list === "") list = [];
                                     if (require('util').isArray(list[0])) {
                                         list = list[0];
                                     }
-                                    list.unshift("/" + i);
-                                    return list;
+                                    return "/" + i + list;
                                 }
 identifierPath              =   a:identifier b:identifierPathParts? { return a + b; }
 selectList                  =   
@@ -344,7 +345,7 @@ part                        =   booleanFunc /
                                         value: l
                                     };
                                 } /
-                                (u:identifier { 
+                                (u:identifierPath {
                                     return { 
                                         type: 'property', name: u
                                     }; 
@@ -384,6 +385,7 @@ exp                         =
                                 format /
                                 inlinecount /
                                 select /
+                                callback /
                                 unsupported
 
 query                       = list:expList {

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -291,6 +291,16 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.error, 'invalid $format parameter');
     });
 
+    it('should parse long paths in $filter conditions', function () {
+        var ast = parser.parse("$filter=publisher/president/likes/author/firstname eq 'John'");
+        assert.equal(ast.$filter.left.name, "publisher/president/likes/author/firstname");
+    });
+
+    it('should parse $callback', function () {
+        var ast = parser.parse("$callback=jQuery191039675481244921684_1424879147656");
+        assert.equal(ast.$callback, "jQuery191039675481244921684_1424879147656");
+    });
+
     // it('xxxxx', function () {
     //     var ast = parser.parse("$top=2&$filter=Date gt datetime'2012-09-27T21:12:59'");
 


### PR DESCRIPTION
Greetings.
We've stumbled upon an issue with odata-parser while developing [OData API for our graph database](http://nitrosdata.com/): while filter conditions on trivial resource names did work fine, filters on properties with deeper nested level, such as [http://nitrosdata.com/service/testdb/book?$filter=publisher/president/likes/author/firstname eq 'Livia'](http://nitrosdata.com/service/testdb/book?$filter=publisher/president/likes/author/firstname%20eq%20'Livia'), resulted in either an error or a comma-separated list of parts. Turned out pegjs grammar produced an array of strings instead of a single string, and this array got joined automatically somewhere, proposed pull request should fix that.
Oh, and we've also added support for callbacks that some grid controls use.