### PR TITLE
fix: literal filters should accept quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib/odata-parser.js
+.project

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -159,7 +159,8 @@ nanInfinity                 =   nan / negativeInfinity / positiveInfinity
  */
 
 unreserved                  = a:[a-zA-Z0-9-_]+ { return a.join(''); }
-validstring                 = a:[^']* { return a.join(''); }
+validstring                 = a:([^']/escapedQuote)* { return a.join('').replace(/('')/g, "'"); }
+escapedQuote                = a:"''" { return a; }
 identifierPart              = a:[a-zA-Z] b:unreserved { return a + b; }
 identifier                  = 
                                 a:identifierPart list:("." i:identifier {return i;})? {

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -87,6 +87,26 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.value, "Jef");
     });
     
+    it('should parse $filter containing quote', function () {
+
+      var ast = parser.parse("$filter=Name eq 'O''Neil'");
+
+      assert.equal(ast.$filter.type, "eq");
+      assert.equal(ast.$filter.left.type, "property");
+      assert.equal(ast.$filter.left.name, "Name");
+      assert.equal(ast.$filter.right.type, "literal");
+      assert.equal(ast.$filter.right.value, "O'Neil");
+  });
+
+    it('should parse $filter with subproperty', function () {
+	var ast = parser.parse("$filter=User/Name eq 'Jef'");
+	assert.equal(ast.$filter.type, "eq");
+	assert.equal(ast.$filter.left.type, "property");
+	assert.equal(ast.$filter.left.name, "User/Name");
+	assert.equal(ast.$filter.right.type, "literal");
+	assert.equal(ast.$filter.right.value, "Jef");
+    });
+    
     it('should parse multiple conditions in a $filter', function () {
 
         var ast = parser.parse("$filter=Name eq 'John' and LastName lt 'Doe'");
@@ -125,6 +145,32 @@ describe('odata.parser grammar', function () {
         
         assert.equal(ast.$filter.args[0].type, "literal");
         assert.equal(ast.$filter.args[0].value, "");
+
+    });
+
+    it('should parse substringof $filter with string containing quote', function () {
+
+      var ast = parser.parse("$filter=substringof('ng''inx', Data)");
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "ng'inx");
+
+    });
+    
+    it('should parse substringof $filter with string starting with quote', function () {
+
+      var ast = parser.parse("$filter=substringof('''nginx', Data)");
+      
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "'nginx");
+
+    });
+    
+    it('should parse substringof $filter with string ending with quote', function () {
+
+      var ast = parser.parse("$filter=substringof('nginx''', Data)");
+      
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "nginx'");
 
     });
 
@@ -289,16 +335,6 @@ describe('odata.parser grammar', function () {
 
         ast = parser.parse('$format=');
         assert.equal(ast.error, 'invalid $format parameter');
-    });
-
-    it('should parse long paths in $filter conditions', function () {
-        var ast = parser.parse("$filter=publisher/president/likes/author/firstname eq 'John'");
-        assert.equal(ast.$filter.left.name, "publisher/president/likes/author/firstname");
-    });
-
-    it('should parse $callback', function () {
-        var ast = parser.parse("$callback=jQuery191039675481244921684_1424879147656");
-        assert.equal(ast.$callback, "jQuery191039675481244921684_1424879147656");
     });
 
     // it('xxxxx', function () {


### PR DESCRIPTION
According to OData documentation : "_One of these rules is that single quotes within string literals are represented as two consecutive single quotes._".

http://docs.oasis-open.org/odata/odata/v4.0/odata-v4.0-part2-url-conventions.html