### PR TITLE
complex and/or filters parsing fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "rm -f lib/odata-parser.js && npm run-script prepublish && mocha -R spec",
-    "prepublish": "pegjs src/odata.pegjs lib/odata-parser.js"
+    "prepublish": "pegjs src/odata.pegjs lib/odata-parser.js",
     "preinstall": "pegjs src/odata.pegjs lib/odata-parser.js"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "rm -f lib/odata-parser.js && npm run-script prepublish && mocha -R spec",
     "prepublish": "pegjs src/odata.pegjs lib/odata-parser.js"
+    "preinstall": "pegjs src/odata.pegjs lib/odata-parser.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -5,6 +5,20 @@
  *  - https://github.com/dmajda/pegjs
  */
 
+{
+  function filterExprHelper(left, right){
+    if (right) {
+        return {
+            type: right.type,
+            left: left,
+            right: right.value
+        }
+    } else {
+        return left;
+    }
+  }
+}
+
 start                       = query
 
 /*
@@ -259,20 +273,15 @@ filter                      =   "$filter=" list:filterExpr {
                             /   "$filter=" .* { return {"error": 'invalid $filter parameter'}; }
 
 filterExpr                  = 
-                              "(" WSP? filterExpr WSP? ")" ( WSP ("and"/"or") WSP filterExpr)? / 
+                              left:("(" WSP? filter:filterExpr WSP? ")"{return filter}) right:( WSP type:("and"/"or") WSP value:filterExpr{
+                                    return { type: type, value: value}
+                              })? {
+                                return filterExprHelper(left, right);
+                              } / 
                               left:cond right:( WSP type:("and"/"or") WSP value:filterExpr{
                                     return { type: type, value: value}
                               })? {
-
-                                if (right) {
-                                    return {
-                                        type: right.type,
-                                        left: left,
-                                        right: right.value
-                                    }
-                                } else {
-                                    return left;
-                                }
+                                return filterExprHelper(left, right);
                               }
 
 booleanFunctions2Args       = "substringof" / "endswith" / "startswith" / "IsOf"

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -104,6 +104,27 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.right.value, "Doe");
     });
 
+    it('should parse multiple complex conditions in a $filter', function () {
+
+        var ast = parser.parse("$filter=Name eq 'John' and (LastName lt 'Doe' or LastName gt 'Aro')");
+
+        assert.equal(ast.$filter.type, "and");
+        assert.equal(ast.$filter.left.type, "eq");
+        assert.equal(ast.$filter.left.left.type, "property");
+        assert.equal(ast.$filter.left.left.name, "Name");
+        assert.equal(ast.$filter.left.right.type, "literal");
+        assert.equal(ast.$filter.left.right.value, "John");
+        assert.equal(ast.$filter.right.type, "or");
+        assert.equal(ast.$filter.right.left.type, "lt");
+        assert.equal(ast.$filter.right.left.left.name, "LastName");
+        assert.equal(ast.$filter.right.left.right.type, "literal");
+        assert.equal(ast.$filter.right.left.right.value, "Doe");
+        assert.equal(ast.$filter.right.right.type, "gt");
+        assert.equal(ast.$filter.right.right.left.name, "LastName");
+        assert.equal(ast.$filter.right.right.right.type, "literal");
+        assert.equal(ast.$filter.right.right.right.value, "Aro");
+    });
+
     it('should parse substringof $filter', function () {
 
         var ast = parser.parse("$filter=substringof('nginx', Data)");


### PR DESCRIPTION
#18 related changes. It can't handle operator precedence. However, it works if brackets as required are added. Please let me know if more tests need to be added. 