### PR TITLE
[~] add support for single-char identifiers

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -160,7 +160,7 @@ nanInfinity                 =   nan / negativeInfinity / positiveInfinity
 
 unreserved                  = a:[a-zA-Z0-9-_]+ { return a.join(''); }
 validstring                 = a:[^']* { return a.join(''); }
-identifierPart              = a:[a-zA-Z] b:unreserved { return a + b; }
+identifierPart              = a:[a-zA-Z] b:unreserved? { return a + b; }
 identifier                  = 
                                 a:identifierPart list:("." i:identifier {return i;})? {
                                     if (list === "") list = [];

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -66,6 +66,13 @@ describe('odata.parser grammar', function () {
 
         assert.equal(ast.$select[0], 'DemoService.*');
     });
+
+    it('should accept single-char field in $select', function () {
+
+        var ast = parser.parse('$select=r');
+
+        assert.equal(ast.$select[0], 'r');
+    });
     
     it('should parse order by', function () {
 


### PR DESCRIPTION
related to issue #14. single-char identifiers are allowed everywhere, e.g in $filter, $orderby, $select etc.
Please let me know if more tests need to be added.