### PR TITLE
Fix minor bugs in the grammar

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -65,12 +65,12 @@ byte                        =   DIGIT DIGIT DIGIT
 
 dateTime                    =   "datetime" SQUOTE a:dateTimeBody SQUOTE { return new Date(a); }
 
-dateTimeOffset              =   "datetimeoffset" SQUOTE dateTimeOffsetBody SQUOTE
+dateTimeOffset              =   "datetimeoffset" SQUOTE a:dateTimeOffsetBody SQUOTE { return new Date(a); }
 
-dateTimeBodyA               =  a:year "-" b:month "-" c:day "T" d:hour ":" e:minute "Z"? {
+dateTimeBodyA               =  a:year "-" b:month "-" c:day "T" d:hour ":" e:minute {
                                     return a + '-' + b + '-' + c + "T" + d + ":" + e;
                                 }
-dateTimeBodyB               =  a:dateTimeBodyA ":" b:second "Z"? { return a + ":" + b; }
+dateTimeBodyB               =  a:dateTimeBodyA ":" b:second { return a + ":" + b; }
 dateTimeBodyC               =  a:dateTimeBodyB "." b:nanoSeconds { return a + "." + b; }
 dateTimeBodyD               =  a:dateTimeBodyC "-" b:zeroToTwentyFour ":" c:zeroToSixty {
                                     return a + "-" + b + ":" + c;
@@ -81,11 +81,11 @@ dateTimeBody                =
                              / dateTimeBodyB
                              / dateTimeBodyA
 
-dateTimeOffsetBody          =   dateTimeBody "Z" / // TODO: is the Z optional?
-                                dateTimeBody sign zeroToThirteen ":00" /
-                                dateTimeBody sign zeroToThirteen /
-                                dateTimeBody sign zeroToTwelve ":" zeroToSixty /
-                                dateTimeBody sign zeroToTwelve
+dateTimeOffsetBody          =   a:dateTimeBody "Z" { return a + "Z"; } /
+                                a:dateTimeBody b:sign c:zeroToThirteen ":00" { return a + b + c + ":00"; } /
+                                a:dateTimeBody b:sign c:zeroToThirteen { return a + b + c; } /
+                                a:dateTimeBody b:sign c:zeroToTwelve ":" d:zeroToSixty { return a + b + c + ":" + d; } /
+                                a:dateTimeBody b:sign c:zeroToTwelve { return a + b + c; }
 
 decimal                     =  sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("M"/"m")? { return sign + digit.join('') + '.' + decimal.join(''); } /
                                sign:sign? digit:DIGIT+ ("M"/"m") { return sign + digit.join(''); }

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -88,7 +88,7 @@ dateTimeOffsetBody          =   dateTimeBody "Z" / // TODO: is the Z optional?
                                 dateTimeBody sign zeroToTwelve
 
 decimal                     =  sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("M"/"m")? { return sign + digit.join('') + '.' + decimal.join(''); } /
-                               sign? DIGIT+ ("M"/"m") { return sign + digit.join(''); }
+                               sign:sign? digit:DIGIT+ ("M"/"m") { return sign + digit.join(''); }
 
 double                      =  sign:sign? digit:DIGIT "." decimal:DIGIT+ ("e" / "E") signexp:sign? exp:DIGIT+ ("D" / "d")? { return sign + digit + '.' + decimal.join('') + 'e' + signexp + exp.join(''); } /
                                sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("D" / "d") { return sign + digit.join('') + '.' + decimal.join(''); } /

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -313,18 +313,18 @@ otherFunc2                 = f:otherFunctions2Arg "(" arg0:part "," WSP? arg1:pa
                                       args: [arg0, arg1]
                                   }
                               } /
-                              "substring(" "(" arg0:part "," WSP? arg1:part "," WSP? arg2:part ")" {
+                              "substring" "(" arg0:part "," WSP? arg1:part "," WSP? arg2:part ")" {
                                   return {
                                       type: "functioncall",
                                       func: "substring",
-                                      args: [arg0, arg1, ag2]
+                                      args: [arg0, arg1, arg2]
                                   }
                               } /
-                              "replace(" "(" arg0:part "," WSP? arg1:part "," WSP? arg2:part ")" {
+                              "replace" "(" arg0:part "," WSP? arg1:part "," WSP? arg2:part ")" {
                                   return {
                                       type: "functioncall",
                                       func: "replace",
-                                      args: [arg0, arg1, ag2]
+                                      args: [arg0, arg1, arg2]
                                   }
                               }
 

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -211,6 +211,26 @@ describe('odata.parser grammar', function () {
       });
     });
 
+    ['substring', 'replace'].forEach(function (func) {
+      it('should parse ' + func + ' $filter with 3 args', function() {
+        var ast = parser.parse("$filter=" + func + "('haystack', needle, foo) eq 'test'");
+
+        assert.equal(ast.$filter.type, "eq");
+
+        assert.equal(ast.$filter.left.type, "functioncall");
+        assert.equal(ast.$filter.left.func, func);
+        assert.equal(ast.$filter.left.args[0].type, "literal");
+        assert.equal(ast.$filter.left.args[0].value, "haystack");
+        assert.equal(ast.$filter.left.args[1].type, "property");
+        assert.equal(ast.$filter.left.args[1].name, "needle");
+        assert.equal(ast.$filter.left.args[2].type, "property");
+        assert.equal(ast.$filter.left.args[2].name, "foo");
+
+        assert.equal(ast.$filter.right.type, "literal");
+        assert.equal(ast.$filter.right.value, "test");
+      });
+    });
+
     it('should return an error if invalid value', function() {
 
         var ast = parser.parse("$top=foo");

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -193,6 +193,20 @@ describe('odata.parser grammar', function () {
       });
     });
 
+    it('should parse year datetimeoffset $filter', function() {
+        var ast = parser.parse("$filter=my_year lt year(datetimeoffset'2016-01-01T01:01:01Z')");
+
+        assert.equal(ast.$filter.type, "lt");
+
+        assert.equal(ast.$filter.left.type, "property");
+        assert.equal(ast.$filter.left.name, "my_year");
+
+        assert.equal(ast.$filter.right.type, "functioncall");
+        assert.equal(ast.$filter.right.func, "year");
+        assert.equal(ast.$filter.right.args[0].type, "literal");
+        assert.ok(ast.$filter.right.args[0].value instanceof Date);
+    });
+
     ['indexof', 'concat', 'substring', 'replace'].forEach(function (func) {
       it('should parse ' + func + ' $filter', function () {
         var ast = parser.parse("$filter=" + func + "('haystack', needle) eq 'test'");


### PR DESCRIPTION
In the grammar definition, arguments to replace() had a typo. Instead of
"ag2", it should be "arg2".

Also, substring() and replace() had an extra leading parenthesis defined
in the grammar. This is fixed as well.

The definition for "decimal" did not label arguments correctly in the
grammar. It is now fixed so that they get passed as args in the
generated parser.