### PR TITLE
Add precedence grouping support to $filter expressions.

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -258,8 +258,18 @@ filter                      =   "$filter=" list:filterExpr {
                                 }
                             /   "$filter=" .* { return {"error": 'invalid $filter parameter'}; }
 
-filterExpr                  = 
-                              "(" WSP? filterExpr WSP? ")" ( WSP ("and"/"or") WSP filterExpr)? / 
+filterExpr                  = "(" WSP? left:filterExpr WSP? ")" right:( WSP type:("and"/"or") WSP value:filterExpr {return {type: type, value: value}})?
+                              {
+                                if (right) {
+                                  return {
+                                    type: right.type,
+                                    left: left,
+                                    right: right.value
+                                  }
+                                }
+                                return left;
+                              }
+                              /
                               left:cond right:( WSP type:("and"/"or") WSP value:filterExpr{
                                     return { type: type, value: value}
                               })? {

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -86,7 +86,42 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.type, "literal");
         assert.equal(ast.$filter.right.value, "Jef");
     });
-    
+
+    it('should parse condition in brackets in a $filter', function () {
+
+        var ast = parser.parse("$filter=(Name eq 'Jef')");
+
+        assert.equal(ast.$filter.type, "eq");
+        assert.equal(ast.$filter.left.type, "property");
+        assert.equal(ast.$filter.left.name, "Name");
+        assert.equal(ast.$filter.right.type, "literal");
+        assert.equal(ast.$filter.right.value, "Jef");
+    });
+
+    it('should parse expression consisting expression that uses brackets in a $filter', function () {
+        var ast = parser.parse("$filter=(Name eq 'Jane') or (age gt '18' and age lt '35')");
+
+        assert.equal(ast.$filter.type, "or");
+        assert.equal(ast.$filter.left.type, "eq");
+        assert.equal(ast.$filter.left.left.type, "property");
+        assert.equal(ast.$filter.left.left.name, "Name");
+        assert.equal(ast.$filter.left.right.type, "literal");
+        assert.equal(ast.$filter.left.right.value, "Jane");
+
+        assert.equal(ast.$filter.right.type, "and");
+        assert.equal(ast.$filter.right.left.type, "gt");
+        assert.equal(ast.$filter.right.left.left.type, "property");
+        assert.equal(ast.$filter.right.left.left.name, "age");
+        assert.equal(ast.$filter.right.left.right.type, "literal");
+        assert.equal(ast.$filter.right.left.right.value, "18");
+
+        assert.equal(ast.$filter.right.right.type, "lt");
+        assert.equal(ast.$filter.right.right.left.type, "property");
+        assert.equal(ast.$filter.right.right.left.name, "age");
+        assert.equal(ast.$filter.right.right.right.type, "literal");
+        assert.equal(ast.$filter.right.right.right.value, "35");
+    });
+
     it('should parse multiple conditions in a $filter', function () {
 
         var ast = parser.parse("$filter=Name eq 'John' and LastName lt 'Doe'");


### PR DESCRIPTION
`$filter=(substringof(name eq 'search term') or substringof(nickname eq 'search term')) and age gt 21` is a valid expression in oData. The aim of this pull request to add support for [precedence grouping](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398301).