### PR TITLE
Update odata.pegjs

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -285,7 +285,7 @@ filterExpr                  =
                                 return filterExprHelper(left, right);
                               }
 
-booleanFunctions2Args       = "substringof" / "endswith" / "startswith" / "IsOf"
+booleanFunctions2Args       = "substringof" / "endswith" / "startswith" / "IsOf" / "contains"
 
 booleanFunc                 =  f:booleanFunctions2Args "(" arg0:part "," WSP? arg1:part ")" {
                                     return {


### PR DESCRIPTION
Hello,

just added filter option "contains" which is really missing for openUI5 usage. It looks like the same as substringof. here some links where those assumed to be supported for oData v4.
http://docs.oasis-open.org/odata/odata/v4.0/odata-v4.0-part2-url-conventions.html (section 4.12)
https://openui5.hana.ondemand.com/#docs/api/symbols/sap.ui.model.FilterOperator.html 

BR,
Denis