### PR TITLE
Add basic ‘contains’ functionality.

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -285,7 +285,7 @@ filterExpr                  =
                                 return filterExprHelper(left, right);
                               }
 
-booleanFunctions2Args       = "substringof" / "endswith" / "startswith" / "IsOf"
+booleanFunctions2Args       = "contains" / "substringof" / "endswith" / "startswith" / "IsOf"
 
 booleanFunc                 =  f:booleanFunctions2Args "(" arg0:part "," WSP? arg1:part ")" {
                                     return {

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -239,6 +239,21 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.value, true);
     });
 
+    it('should parse contains $filter', function () {
+
+        var ast = parser.parse("$filter=contains('nginx', Data)");
+
+        assert.equal(ast.$filter.type, "functioncall");
+        assert.equal(ast.$filter.func, "contains");
+
+        assert.equal(ast.$filter.args[0].type, "literal");
+        assert.equal(ast.$filter.args[0].value, "nginx");
+
+        assert.equal(ast.$filter.args[1].type, "property");
+        assert.equal(ast.$filter.args[1].name, "Data");
+
+    });
+
     it('should parse startswith $filter', function () {
 
         var ast = parser.parse("$filter=startswith('nginx', Data)");


### PR DESCRIPTION
At minimum I am adding this so that parsing does not break when I use the contains function.

closes https://github.com/auth0/node-odata-parser/issues/45